### PR TITLE
[fix] bug when using min mode earlystop

### DIFF
--- a/recstudio/utils/callbacks.py
+++ b/recstudio/utils/callbacks.py
@@ -104,7 +104,7 @@ class EarlyStopping(object):
                 self._counter += 1
         else:
             if metrics[self.monitor] <= self.best_value-self.delta:
-                self._reset_counter(model, epoch, metrics[self.monitor])
+                self._reset_counter(model, epoch, metrics)
                 self.logger.info("{} improved. Best value: {:.4f}".format(
                                 self.monitor, metrics[self.monitor]))
             else:


### PR DESCRIPTION
The 3rd parameter of function _reset_counter(self, model: torch.nn.Module, epoch, value) should be a dict