### PR TITLE
[feat] add support for nni

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,6 @@ cython_debug/
 
 tensorboard/
 .vscode/
-nni-experiments/
 **/log
 **/saved
 **/.recstudio

--- a/nni-experiments/config/BPR.yaml
+++ b/nni-experiments/config/BPR.yaml
@@ -1,0 +1,35 @@
+experimentName: BPR-ml-100k
+searchSpaceFile: ../search_space/BPR.json
+
+trialCommand: python3 run.py -m BPR --mode tune
+trialCodeDirectory: ../..
+trialGpuNumber: 1
+
+trialConcurrency: 4            # Run 4 trials concurrently.
+maxTrialNumber: 1000              # Generate at most 10 trials.
+maxExperimentDuration: 100d       # Stop generating trials after 1 hour.
+
+tuner:                          # Configure the tuning algorithm.
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+
+# assessor:
+#   name: Curvefitting
+#   classArgs:
+#     epoch_num: 200
+#     start_step: 20
+#     threshold: 0.9
+#     gap: 1
+
+# assessor:
+#   name: Medianstop
+#   classArgs:
+#     optimize_mode: maximize
+#     start_step: 200
+
+trainingService:
+  platform: local
+  useActiveGpu: true
+  gpuIndices: 0,1
+  maxTrialNumberPerGpu: 2

--- a/nni-experiments/config/SASRec.yaml
+++ b/nni-experiments/config/SASRec.yaml
@@ -1,0 +1,37 @@
+experimentName: SASRec-ml-100k
+searchSpaceFile: ../search_space/SASRec.json
+
+trialCommand: python3 run.py -m SASRec --mode tune
+trialCodeDirectory: ../..
+trialGpuNumber: 1
+
+trialConcurrency: 4            # Run 4 trials concurrently.
+maxTrialNumber: 1000              # Generate at most 10 trials.
+maxExperimentDuration: 100d       # Stop generating trials after 1 hour.
+
+tuner:                          # Configure the tuning algorithm.
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+
+# assessor:
+#   name: Curvefitting
+#   classArgs:
+#     epoch_num: 200
+#     start_step: 20
+#     threshold: 0.9
+#     gap: 1
+
+# assessor:
+#   name: Medianstop
+#   classArgs:
+#     optimize_mode: maximize
+#     start_step: 200
+# Configure the training platform.
+# Supported platforms: local, remote, openpai, aml, kubeflow, kubernetes, adl.
+
+trainingService:
+  platform: local
+  useActiveGpu: true
+  gpuIndices: 0,1
+  maxTrialNumberPerGpu: 2

--- a/nni-experiments/search_space/BPR.json
+++ b/nni-experiments/search_space/BPR.json
@@ -1,9 +1,9 @@
 {
-    "learning_rate": {
+    "train/learning_rate": {
         "_type": "choice",
         "_value": [0.001]
     },
-    "weight_decay": {
+    "train/weight_decay": {
         "_type": "choice",
         "_value": [0.0001, 0.0005, 0.001, 0.005]
     }

--- a/nni-experiments/search_space/BPR.json
+++ b/nni-experiments/search_space/BPR.json
@@ -1,0 +1,10 @@
+{
+    "learning_rate": {
+        "_type": "choice",
+        "_value": [0.001]
+    },
+    "weight_decay": {
+        "_type": "choice",
+        "_value": [0.0001, 0.0005, 0.001, 0.005]
+    }
+}

--- a/nni-experiments/search_space/SASRec.json
+++ b/nni-experiments/search_space/SASRec.json
@@ -1,0 +1,10 @@
+{
+    "train/learning_rate": {
+        "_type": "choice",
+        "_value": [0.0005, 0.001, 0.005]
+    },
+    "model/dropout_rate": {
+        "_type": "choice",
+        "_value": [0.2, 0.5]
+    }
+}

--- a/recstudio/model/basemodel/recommender.py
+++ b/recstudio/model/basemodel/recommender.py
@@ -30,9 +30,6 @@ class Recommender(torch.nn.Module, abc.ABC):
         else:
             self.config = parser_yaml(os.path.join(os.path.dirname(__file__), "basemodel.yaml"))
 
-        if kwargs['run_mode'] == 'tune':
-            self._update_config_with_nni()
-
         if self.config['train']['seed'] is not None:
             seed_everything(self.config['train']['seed'], workers=True)
 
@@ -98,15 +95,6 @@ class Recommender(torch.nn.Module, abc.ABC):
                 self.loss_fn = self._get_loss_func(train_data)
             else:
                 self.loss_fn = self._get_loss_func()
-
-    def _update_config_with_nni(self):
-        next_parameter = nni.get_next_parameter() # Updated config dict
-        # Model config is given a higher priority when config entry name conflicts
-        for k, v in next_parameter.items():
-            if k in self.config['model'].keys(): 
-                self.config['model'].update({k: v})
-            elif k in self.config['train'].keys():
-                self.config['train'].update({k: v})
 
     def fit(
         self,

--- a/recstudio/quickstart/run.py
+++ b/recstudio/quickstart/run.py
@@ -1,4 +1,4 @@
-import os, nni, datetime, torch
+import os, datetime, torch
 from typing import *
 from recstudio.utils import *
 
@@ -30,15 +30,7 @@ def run(model: str, dataset: str, model_config: Dict=None, data_config: Dict=Non
 
     logger.info("Log saved in {}.".format(os.path.abspath(log_path)))
     if run_mode == 'tune':
-        next_parameter = nni.get_next_parameter() # Updated config dict
-        for k, v in next_parameter.items():
-            para_name = k.split('/')
-            assert len(para_name) == 2 and para_name[0] in ['train', 'model'], \
-                'The format of NNI search space entry should be train/XXX or model/XXX.'
-            if model_conf[para_name[0]].get(para_name[1]) == None:
-                logger.warning(f"NNI search space variable {para_name[1]} doesn't exist in config/{para_name[0]}")
-            else:
-                model_conf[para_name[0]][para_name[1]] = v
+        model_conf = update_config_with_nni(model_conf)
     model = model_class(model_conf)
     dataset_class = model_class._get_dataset_class()
 

--- a/run.py
+++ b/run.py
@@ -11,4 +11,4 @@ if __name__ == '__main__':
     model_class, model_conf = get_model(args.model)
     model_conf = deep_update(model_conf, command_line_conf)
 
-    quickstart.run(args.model, args.dataset, model_config=model_conf, data_config_path=args.data_config_path)
+    quickstart.run(args.model, args.dataset, model_config=model_conf, data_config_path=args.data_config_path, run_mode=args.mode)


### PR DESCRIPTION
It's convenient to utilize the Auto-ML tool to help tune the deep learning models, but I find the `--mode tune` argument is not actually working. Besides, I notice that #27 also aims to add support for NNI but it has not been updated for six months. So I open this pull request to add support for [NNI](https://github.com/microsoft/nni).

I've made the following changes corresponding to the following code changes:
1. Add config files and search space files in `./nni-experiments`.
2. Add necessary functions for NNI: (a) config file updating (b) intermediate and final results reporting (c) GPU selection.
3. As NNI may create several trials within one second, I add a microsecond field to the checkpoint path to avoid conflicts.
4. Remove original unused codes related to NNI.

Possible hidden problems:
1. As NNI assigns gpu index for each trial automatically, the current code may not be used for DDP.
2. I only test the tuning mode with BPR and SASRec.

Pip packages requirements:
1. `pip install nni==2.10`
2. `pip install 'typeguard<3'` (This is required for solving the errors in NNI and the detailed info can be found [here](https://github.com/microsoft/nni/issues/5457).)

Compatibility analysis:

- [x] Light mode
- [x] Log files in tune mode
- [x] Tensorboad logs in tune mode
- [x] NNI logs in tune mode

Usage example:
1. Create a new experiment: `nnictl create --config ./nni-experiments/config/BPR.yaml --port 14015`
2. List existing experiments: `nnictl experiment list --all`
3. Stop some experiments: `nnictl stop EXPERIMENT_ID`
